### PR TITLE
[v1.3.1] Add Update App Popup and Style Scrollbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-github-btn": "^1.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "react-toastify": "^7.0.3",
     "serializr": "^2.0.5",
     "typescript": "^4.2.2",
     "web-vitals": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drg-completionist",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,11 @@ import { Col, BackTop, Layout, PageHeader, Row, Typography, Spin } from 'antd';
 import 'antd/dist/antd.dark.css';
 import React, { lazy } from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { Slide, ToastContainer } from 'react-toastify';
 import { Assignment } from 'assets/other';
 import PageFooter from 'components/PageFooter';
 import PageTabs from 'components/PageTabs';
+import 'react-toastify/dist/ReactToastify.css';
 
 const { Content } = Layout;
 const { Title } = Typography;
@@ -51,6 +53,11 @@ export const TABS: Array<{
 export default function App() {
   return (
     <Layout style={{ backgroundColor: '#1a1a1a' }}>
+      <ToastContainer
+        hideProgressBar
+        position="top-center"
+        transition={Slide}
+      />
       <BackTop style={{ bottom: 110 }} />
       <Content style={{ marginBottom: 100 }}>
         <Row justify="center">

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,8 @@ code {
   user-select: none;
 }
 
+/* Toast Styles */
+
 .Toastify__toast {
   justify-content: center;
 }
@@ -30,9 +32,9 @@ code {
 
 /* Scroll Bar Styles */
 
-body {
+:-webkit-any(body) {
   overflow: overlay;
-  scrollbar-color: auto;
+  width: 100% !important;
 }
 
 ::-webkit-scrollbar {

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,14 @@ code {
   user-select: none;
 }
 
+.Toastify__toast {
+  justify-content: center;
+}
+
+.Toastify__close-button {
+  visibility: hidden;
+}
+
 /* Scroll Bar Styles */
 
 body {

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,3 +1,6 @@
+import { isMobile } from 'react-device-detect';
+import { toast } from 'react-toastify';
+
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
@@ -15,7 +18,9 @@ const isLocalhost = Boolean(
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
     // 127.0.0.0/8 are considered localhost for IPv4.
-    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
 );
 
 type Config = {
@@ -77,6 +82,30 @@ function registerValidSW(swUrl: string, config?: Config) {
                   'tabs for this page are closed. See https://cra.link/PWA.'
               );
 
+              const reloadPage = () => {
+                if (registration.waiting) {
+                  registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+                  location.reload();
+                }
+              };
+
+              toast.info(
+                `Update available! ${
+                  isMobile ? 'Tap' : 'Click'
+                } here to upgrade.`,
+                {
+                  onClick: () => reloadPage(),
+                  autoClose: false,
+                  closeOnClick: false,
+                  draggable: false,
+                  hideProgressBar: false,
+                  pauseOnHover: true,
+                  position: 'top-center',
+                  progress: undefined,
+                  toastId: 'swUpdateAvailable',
+                }
+              );
+
               // Execute callback
               if (config && config.onUpdate) {
                 config.onUpdate(registration);
@@ -125,7 +154,9 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      console.log(
+        'No internet connection found. App is running in offline mode.'
+      );
     });
 }
 

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -82,7 +82,7 @@ function registerValidSW(swUrl: string, config?: Config) {
                   'tabs for this page are closed. See https://cra.link/PWA.'
               );
 
-              const reloadPage = () => {
+              const updateAndReloadPage = () => {
                 if (registration.waiting) {
                   registration.waiting.postMessage({ type: 'SKIP_WAITING' });
                   location.reload();
@@ -94,7 +94,7 @@ function registerValidSW(swUrl: string, config?: Config) {
                   isMobile ? 'Tap' : 'Click'
                 } here to upgrade.`,
                 {
-                  onClick: () => reloadPage(),
+                  onClick: () => updateAndReloadPage(),
                   autoClose: false,
                   closeOnClick: false,
                   draggable: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,6 +3525,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -10009,6 +10014,13 @@ react-scripts@4.0.3:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-toastify@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.3.tgz#93804c777ecf918872ba3b5be9c654db14547f85"
+  integrity sha512-cxZ5rfurC8LzcZQMTYc8RHIkQTs+BFur18Pzk6Loz6uS8OXUWm6nXVlH/wqglz4Z7UAE8xxcF5mRjfE13487uQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.1:
   version "17.0.1"


### PR DESCRIPTION
**Changes:**
* Add an update toast that appears at the top of the app when the service workers detects changes from its current cached version.
  * Clicking it downloads the changes and reloads the app with the new changes.
  * This seems to be taken care of automatically on mobile browsers.
* Update scrollbar styling on WebKit browsers (e.g., Safari, Chrome)
* Fix some of the popping back and forth in the overall progress bar when a modal is opened or closed